### PR TITLE
added gracely error return type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,11 @@
             "node-webcrypto-ossl": "1.0.48"
           }
         },
+        "gracely": {
+          "version": "0.0.24",
+          "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.24.tgz",
+          "integrity": "sha512-eR86LPiK5mdUtoyn7BsTA9Rl6XGs6oiwQSjO+BK9Se3wpRhX4GyI+hTSC/SGjdAewMtX/S9k/6A7W3CWeOul5Q=="
+        },
         "isoly": {
           "version": "0.0.11",
           "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.11.tgz",
@@ -2184,9 +2189,9 @@
       "dev": true
     },
     "gracely": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.24.tgz",
-      "integrity": "sha512-eR86LPiK5mdUtoyn7BsTA9Rl6XGs6oiwQSjO+BK9Se3wpRhX4GyI+hTSC/SGjdAewMtX/S9k/6A7W3CWeOul5Q=="
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.25.tgz",
+      "integrity": "sha512-9BhYoCiX7x8alMgizd8h43XziFhebgYDHT+nmKepJKwC5pafFDmZgEsJoboBFQXn6ARGUi/V6AWE1KA955BFpw=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@cardfunc/model": "^0.0.48",
     "authly": "^0.0.35",
+    "gracely": "^0.0.25",
     "isoly": "^0.0.12",
     "smoothly": "^0.0.100",
     "smoothly-model": "^0.0.11"

--- a/src/components/element/index.tsx
+++ b/src/components/element/index.tsx
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:no-implicit-dependencies
 import { Component, Event, EventEmitter, Method, Listen, Prop, State, h } from "@stencil/core"
 import { Payload, Verifier, Token } from "authly"
+import { Error } from "gracely"
 import { Trigger } from "smoothly-model"
 import { Authorization } from "@cardfunc/model"
 import { AuthorizationCreatableSafe } from "../model"
@@ -19,7 +20,7 @@ export class Form {
 	@State() verify?: { pareq: string, url: string, issuer: string }
 	@State() authorization?: AuthorizationCreatableSafe
 	@Event() changed: EventEmitter<Authorization>
-	private received?: (state: "succeeded" | "failed", authorization: Authorization | Token) => void
+	private received?: (state: "succeeded" | "failed", authorization: Authorization | Error | Token) => void
 	@State() payload?: Payload
 	componentWillLoad() {
 		Verifier.create("public").verify(this.apiKey).then(payload => this.payload = payload)
@@ -47,7 +48,7 @@ export class Form {
 		}
 	}
 	@Method()
-	submit(authorization: AuthorizationCreatableSafe): Promise<Authorization | Token> {
+	submit(authorization: AuthorizationCreatableSafe): Promise<Authorization | Error | Token> {
 		this.authorization = authorization
 		return new Promise(callback => {
 			if (this.frame) {


### PR DESCRIPTION
##Change

Added return type gracely.Error for handling of error messages when trying to create authorization.

##Rationale

For handling errors that might occur when entering incorrect card data, server issues or any other type of errors.

##Impact

Will give an error instead of a promise of an account, when there might not be an account being sent which would probably crash and confuse endpoint users otherwise.

##Risk

This should have no increased risks on the system. No extra risk analysis is necessary.

##Rollback

For rollback, it is enough to revert the commit and redeploy.