### PR TITLE
Put semi-hidden button in dialog on top

### DIFF
--- a/src/components/element/style.css
+++ b/src/components/element/style.css
@@ -7,3 +7,6 @@
 :host[hidden] {
 	display: none;
 }
+:host > smoothly-dialog > header > smoothly-trigger {
+	z-index: 1;
+}


### PR DESCRIPTION
## Change
Increased z-index on a trigger.

## Rationale
A button was semi-hidden. It should be on top of the dialog that covers it.

## Impact
The change is purely visual. A semi-hidden button is no longer hidden.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.