### PR TITLE
IE compability and dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,23 +255,15 @@
       "dev": true
     },
     "@cardfunc/model": {
-      "version": "0.0.49",
-      "resolved": "https://registry.npmjs.org/@cardfunc/model/-/model-0.0.49.tgz",
-      "integrity": "sha512-LHLO08Ci951M6wzsDFm5yovHUrAu6IB98YP+AMJMOa/SHL4txq/Yn2lMP/wYwLVMvzSmyYapdo7mtsDi5kDTpQ==",
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@cardfunc/model/-/model-0.0.52.tgz",
+      "integrity": "sha512-IvNDEzTe23qIqmjviRhWydyh6vXHP1RLaBkaeJ4zEQRqkijrJCWFc7H+G9Xdpus1xm6JGCyk3285LNMsZXNyDg==",
       "requires": {
-        "authly": "0.0.34",
+        "authly": "0.0.38",
         "gracely": "0.0.24",
         "isoly": "0.0.11"
       },
       "dependencies": {
-        "authly": {
-          "version": "0.0.34",
-          "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.34.tgz",
-          "integrity": "sha512-98ejzKmv3/nE0ycsd3saH44MaogkcvKYzcLoswFV8dPWu7P17ecK9uITimgm/90OFFKmXHXUZTNKOuIEtQqgOw==",
-          "requires": {
-            "node-webcrypto-ossl": "1.0.48"
-          }
-        },
         "gracely": {
           "version": "0.0.24",
           "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.24.tgz",
@@ -1073,9 +1065,9 @@
       "dev": true
     },
     "authly": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.35.tgz",
-      "integrity": "sha512-yJ7BJ3ggRpcJwWVWILR5uqliUB8G+NcyU2RmvsVCA69r0rWJzmp4ml9zPfteSOVi/nkg74ta8J8707At+575Vw==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.38.tgz",
+      "integrity": "sha512-lret5TecRqvBYuq4qqJP0FhxRLvm4ueEWJ2VPVoVnSlXh50xS3/zjRBtgJ8zYEjQdkLPYuXQbgnldnDUjFTI+Q==",
       "requires": {
         "node-webcrypto-ossl": "1.0.48"
       }
@@ -2189,9 +2181,9 @@
       "dev": true
     },
     "gracely": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.25.tgz",
-      "integrity": "sha512-9BhYoCiX7x8alMgizd8h43XziFhebgYDHT+nmKepJKwC5pafFDmZgEsJoboBFQXn6ARGUi/V6AWE1KA955BFpw=="
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.31.tgz",
+      "integrity": "sha512-mT8+V8hZ2dAIdKhdm/s9Ez95HLHvKRGYTR3Vb4GqB9hkm/WH8AxBzLfNwIAFS3/xs61vBM1rE3E0EQkB+u/dPQ=="
     },
     "growly": {
       "version": "1.3.0",
@@ -2559,9 +2551,9 @@
       "dev": true
     },
     "isoly": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.12.tgz",
-      "integrity": "sha512-y/8cANtzRN+gzcbdOgkKxNktvmL4AR3GW+6JttcNVJPgrOH19sR9Ana2CXxVDYD/tZXHi5+Ku8OMnfAEZfy3gA=="
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.13.tgz",
+      "integrity": "sha512-xgmEJjvbkPdoh4DvYcVXojJDHMi+e4wymxmDgTKTKCK1R2jdmxf0YYCJPMynCc9lkVvacGtdI//gTchmzHLyhA=="
     },
     "isstream": {
       "version": "0.1.2",
@@ -5130,14 +5122,21 @@
       "dev": true
     },
     "smoothly": {
-      "version": "0.0.114",
-      "resolved": "https://registry.npmjs.org/smoothly/-/smoothly-0.0.114.tgz",
-      "integrity": "sha512-R9lImnuQnbmmBaYZAGHlVt7aLlQPXYLMRj0b6Gf3Fuf6cRtMpV8349Huu2kt/PDW4sVQvjf5RuCiCN+bcNITGw==",
+      "version": "0.0.118",
+      "resolved": "https://registry.npmjs.org/smoothly/-/smoothly-0.0.118.tgz",
+      "integrity": "sha512-X7FaD8BpIMjeatKfjfnp4qlt4VHB73zKJn3nHf7lj7VW9mTbFXXIKX48txcqXGcAEQW13g3guvSqGnPjsRJwvQ==",
       "requires": {
         "isoly": "0.0.12",
         "normalize.css": "^8.0.1",
         "smoothly-model": "0.0.12",
         "tidily": "0.0.28"
+      },
+      "dependencies": {
+        "isoly": {
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.12.tgz",
+          "integrity": "sha512-y/8cANtzRN+gzcbdOgkKxNktvmL4AR3GW+6JttcNVJPgrOH19sR9Ana2CXxVDYD/tZXHi5+Ku8OMnfAEZfy3gA=="
+        }
       }
     },
     "smoothly-model": {
@@ -5561,6 +5560,13 @@
       "integrity": "sha512-oxlnqNPHEKELdoXDQh5chot4/G2UddE67Zp6H3dr7OmLLmmg+wx2K274B3Es6n/HrwIvvNpEl7kds6SWCu94/Q==",
       "requires": {
         "isoly": "0.0.12"
+      },
+      "dependencies": {
+        "isoly": {
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.12.tgz",
+          "integrity": "sha512-y/8cANtzRN+gzcbdOgkKxNktvmL4AR3GW+6JttcNVJPgrOH19sR9Ana2CXxVDYD/tZXHi5+Ku8OMnfAEZfy3gA=="
+        }
       }
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "clean": "rm -rf .stencil/ dist/ node_modules/ loader/ www/"
   },
   "dependencies": {
-    "@cardfunc/model": "^0.0.49",
-    "authly": "^0.0.35",
-    "gracely": "^0.0.25",
-    "isoly": "^0.0.12",
-    "smoothly": "^0.0.114",
+    "@cardfunc/model": "^0.0.52",
+    "authly": "^0.0.38",
+    "gracely": "^0.0.31",
+    "isoly": "^0.0.13",
+    "smoothly": "^0.0.118",
     "smoothly-model": "^0.0.12"
   },
   "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+		<meta http-equiv="x-ua-compatible" content="IE=Edge">
 		<title>CardFunc Element Test</title>
 
 		<script type="module" src="./build/cardfunc-element.esm.js"></script>


### PR DESCRIPTION
## Change
Added meta-tag to index-file for Internet Explorer 11 compability. Updated authly (payfunc/authly#37) and model (cardfunc/model#52) dependencies for Internet Explorer 11 compability. Updated smoothly to avoid a graphical issue with labels for input fields in Internet Explorer. Updated isoly and gracely dependency to keep the system up to date.

## Rationale
Element doesn't work properly in Internet Explorer 11 at the moment. This update improves support for Internet Explorer and keeps the dependencies up to date.

## Impact
The smoothly and meta-tag change is purely visual and only changes the appearance in Internet Explorer 11. The authly change involves using msCrypto when the regular crypto is missing, which only applies to Internet Explorer 11. The isoly update involves zero-padding of dates, and currently has no direct effect. The gracely change involves improvements for error messages.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.